### PR TITLE
security: run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ COPY --from=server-build /app/server/dist ./server/dist
 COPY --from=frontend-build /app/client/dist ./client/dist
 RUN mkdir -p /app/data
 
-# Create non-root user and set permissions
-RUN addgroup -g 1000 -S appgroup && \
-    adduser -S appuser -u 1000 -G appgroup && \
-    chown -R appuser:appgroup /app
+# Ensure /app is owned by node user (uid=1000, gid=1000)
+RUN chown -R node:node /app
 
-USER appuser
+# Use existing node user from node:22-alpine image
+# node:22-alpine comes with uid=1000, gid=1000 (node user/group)
+USER node
 EXPOSE 3000
 CMD ["node", "server/dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   tidyquest:
     build: .
-    user: "1000:1000"
     ports:
       - "3020:3000"
     volumes:


### PR DESCRIPTION
## Summary

This PR fixes the security warning about running the Docker container as root by introducing a non-root user.

## Changes

- **Dockerfile**: Uses existing  user from  image (UID 1000, GID 1000)
- **Dockerfile**: Set proper ownership of  directory to the node user
- **Dockerfile**: Added `USER node` directive to run the container as non-root
- **docker-compose.yml**: Removed hardcoded `user: "1000:1000"` to avoid conflicts with bind-mounted volumes

## Migration Path for Existing Installations

If you have an existing installation with a `./data` directory mounted as a volume, you may need to update its permissions:

```bash
# Stop the container
docker-compose down

# Update permissions on the data directory (if needed)
sudo chown -R 1000:1000 ./data

# Rebuild and restart
docker-compose build
docker-compose up -d
```

If the `./data` directory doesn't exist yet, Docker will automatically create it with the correct ownership when the container starts.

## Security Benefits

- Follows Docker best practices for running containers as non-root
- Reduces attack surface by limiting container privileges
- Prevents potential privilege escalation vulnerabilities

---

**Update (2026-03-01)**: Addressed reviewer feedback - now uses the existing `node` user instead of creating a custom user with hardcoded UID/GID to avoid conflicts on the node:22-alpine image.