### PR TITLE
Fix: add approve/reject buttons for reward requests (#52)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -114,10 +114,7 @@ function AppContent() {
     }
     if (path === '/rewards') {
       loadRewards();
-      if (user?.role === 'admin') {
-        api.getRewardsAdmin().then((adminData) => setAdminRewardsData(adminData.redemptions)).catch(() => {});
-      }
-    }   
+    }
   }, [location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll every 15s to reflect other users' actions without requiring F5
@@ -138,18 +135,18 @@ function AppContent() {
     };
   }, [user, location.pathname, loadDashboard, refreshRooms]);
 
-const loadRewards = useCallback(async () => {
-  try {
-    const data = await api.getRewards();
-    setRewardsData(data);
-    if (user?.role === 'admin') {
-      const adminData = await api.getRewardsAdmin();
-      setAdminRewardsData(adminData.redemptions);
+  const loadRewards = useCallback(async () => {
+    try {
+      const data = await api.getRewards();
+      setRewardsData(data);
+      if (user?.role === 'admin') {
+        const adminData = await api.getRewardsAdmin();
+        setAdminRewardsData(adminData.redemptions);
+      }
+    } catch {
+      setRewardsData({ rewards: [], mine: [] });
     }
-  } catch {
-    setRewardsData({ rewards: [], mine: [] });
-  }
-}, [user]);
+  }, [user?.role]);
   useEffect(() => {
     if (user) loadRewards();
   }, [user, loadRewards]);
@@ -480,7 +477,7 @@ const loadRewards = useCallback(async () => {
             gamificationEnabled ? (
             <>
               <PageHeader title={t('nav.rewards')} subtitle={t('app.rewardsSubtitle')} user={user} onCoinsClick={() => navigate('/rewards')} onStreakClick={() => navigate('/achievements')} gamificationEnabled={gamificationEnabled} />
-	      <Rewards
+              <Rewards
                 language={user.language}
                 rewards={rewardsData.rewards}
                 mine={rewardsData.mine}
@@ -503,9 +500,6 @@ const loadRewards = useCallback(async () => {
                 }}
                 isAdmin={user.role === 'admin'}
                 adminRedemptions={adminRewardsData}
-
-
-
               />
             </>
             ) : <Navigate to="/" replace />

--- a/client/src/components/pages/Rewards.tsx
+++ b/client/src/components/pages/Rewards.tsx
@@ -18,12 +18,7 @@ interface Redemption {
   status: string;
 }
 
-interface AdminRedemption {
-  id: number;
-  title: string;
-  costCoins: number;
-  redeemedAt: string;
-  status: string;
+interface AdminRedemption extends Redemption {
   displayName: string;
 }
 
@@ -38,6 +33,7 @@ interface RewardsProps {
   onCancel: (redemptionId: number) => Promise<void>;
   onUpdateRedemption?: (id: number, status: 'approved' | 'rejected') => Promise<void>;
 }
+
 export function Rewards({ language, rewards, mine, userCoins, isAdmin, adminRedemptions, onRedeem, onCancel, onUpdateRedemption }: RewardsProps) {
   const { t } = useTranslation(language);
   const [pendingRewardId, setPendingRewardId] = useState<number | null>(null);
@@ -218,10 +214,10 @@ export function Rewards({ language, rewards, mine, userCoins, isAdmin, adminRede
 
       {isAdmin && adminRedemptions && (
         <div className="tq-card tq-card-padded">
-          <h3 className="tq-card-title">🎁 Reward Requests</h3>
+          <h3 className="tq-card-title">{t('dashboard.rewardRequestsTitle')}</h3>
           <div style={{ display: 'grid', gap: 8 }}>
             {adminRedemptions.filter(r => r.status === 'requested').length === 0 ? (
-              <div className="tq-empty-state" style={{ padding: '16px 0' }}>No pending requests</div>
+              <div className="tq-empty-state" style={{ padding: '16px 0' }}>{t('dashboard.rewardRequestEmpty')}</div>
             ) : (
               adminRedemptions.filter(r => r.status === 'requested').map((r) => (
                 <div key={r.id} style={{ border: '1.5px solid var(--warm-border)', borderRadius: 12, padding: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
@@ -230,8 +226,8 @@ export function Rewards({ language, rewards, mine, userCoins, isAdmin, adminRede
                     <div style={{ fontSize: 10, color: 'var(--warm-text-light)', fontWeight: 700 }}>{new Date(r.redeemedAt).toLocaleString()} · {r.costCoins} coins</div>
                   </div>
                   <div style={{ display: 'flex', gap: 6 }}>
-                    <button className="tq-btn tq-btn-primary tq-btn-sm" onClick={() => onUpdateRedemption?.(r.id, 'approved')}>✓ Approve</button>
-                    <button className="tq-btn tq-btn-secondary tq-btn-sm" onClick={() => onUpdateRedemption?.(r.id, 'rejected')}>✗ Reject</button>
+                    <button className="tq-btn tq-btn-primary tq-btn-sm" onClick={() => onUpdateRedemption?.(r.id, 'approved')}>✓ {t('dashboard.approve')}</button>
+                    <button className="tq-btn tq-btn-secondary tq-btn-sm" onClick={() => onUpdateRedemption?.(r.id, 'rejected')}>✗ {t('dashboard.reject')}</button>
                   </div>
                 </div>
               ))
@@ -239,7 +235,6 @@ export function Rewards({ language, rewards, mine, userCoins, isAdmin, adminRede
           </div>
         </div>
       )}
-
 
       {spendFx && (
         <div key={spendFx.key} style={{ position: 'fixed', top: 88, right: 80, zIndex: 121, animation: 'coinSpendFloat 1.4s ease forwards', backgroundColor: 'var(--warm-accent-light)', border: '1.5px solid var(--warm-accent)', borderRadius: 14, padding: '6px 10px', display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 12, fontWeight: 900, color: 'var(--warm-accent)' }}>


### PR DESCRIPTION
## Description
Admins had no way to approve or reject reward requests from the UI.
Requests were stuck at pending indefinitely. Added approve/reject 
buttons to the Rewards page for admin users.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #52

## Changes Made
- Added `AdminRedemption` interface and new admin props to `Rewards.tsx`
- Added admin "Reward Requests" section to the Rewards page UI
- Approve/Reject buttons call existing `PUT /rewards/redemptions/:id` API
- Added `adminRewardsData` state and admin data fetching in `App.tsx`
- Admin section only visible to users with admin role

## Testing
- [x] Tested locally with Docker
- [x] Tested on production-like environment

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have not committed any secrets (.env, API keys, passwords)

## Screenshots

<img width="1251" height="117" alt="image" src="https://github.com/user-attachments/assets/5f1cfecc-5802-45fa-973d-0f74b7ab096c" />



## Additional Notes
The backend API endpoint already existed and was fully functional.
This was purely a missing frontend implementation.