### PR TITLE
Fix: bin icon visibility on night theme (#49)

### DIFF
--- a/client/src/components/pages/History.tsx
+++ b/client/src/components/pages/History.tsx
@@ -86,7 +86,7 @@ export function History({ language, isAdmin }: { language?: string; isAdmin?: bo
                       <button onClick={() => setConfirmCancel(null)} style={{ background: 'none', border: '1px solid var(--warm-text-light)', borderRadius: 8, padding: '3px 7px', fontSize: 10, fontWeight: 700, color: 'var(--warm-text-light)', cursor: 'pointer', fontFamily: 'Nunito' }}>✗</button>
                     </div>
                   ) : (
-                    <button onClick={() => setConfirmCancel(h.id)} title={t('history.cancel')} style={{ background: 'none', border: '1px solid var(--warm-border)', borderRadius: 8, padding: '3px 8px', fontSize: 13, cursor: 'pointer', opacity: 0.6 }}>🗑</button>
+                    <button onClick={() => setConfirmCancel(h.id)} title={t('history.cancel')} style={{ background: 'none', border: '1px solid var(--warm-border)', borderRadius: 8, padding: '3px 8px', fontSize: 13, cursor: 'pointer', color: 'var(--warm-text-muted)' }}>🗑</button>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Description
The bin/delete icon on the Activity page was hard to see in night theme due to a hardcoded opacity value. Replaced with a CSS variable color that adapts correctly to all themes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #49

## Changes Made
- Replaced `opacity: 0.6` with `color: 'var(--warm-text-muted)'` on the
  delete button in `History.tsx`

## Testing
- [x] Tested locally with Docker
- [x] Tested on production-like environment

## Screenshot

<img width="1190" height="56" alt="image" src="https://github.com/user-attachments/assets/51ae77ab-312e-4929-a3cd-bf08f764b120" />


## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have not committed any secrets (.env, API keys, passwords)

## Additional Notes
The fix uses the existing `--warm-text-muted` CSS variable which is 
already defined for all themes including night, ensuring consistent
visibility across all themes.