### PR TITLE
Fix: dashboard card alignment using CSS grid (#47)

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -395,10 +395,10 @@ body {
 .tq-page-medium { max-width: 700px; }
 .tq-page-wide { max-width: 900px; }
 
-/* Dashboard — masonry layout */
+/* Dashboard grid layout */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   grid-auto-rows: auto;
   gap: var(--space-xl);
   animation: fadeIn 0.3s ease;
@@ -554,7 +554,7 @@ html[data-theme='night'] option {
 
   /* Dashboard: force single column on mobile */
   .dashboard-grid {
-    columns: 1 !important;
+    grid-template-columns: 1fr !important;
   }
 
   .page-header {


### PR DESCRIPTION
## Description
Dashboard cards were misaligned when empty due to the use of CSS columns layout which doesn't support equal row alignment. Replaced with CSS Grid for proper card alignment across all states.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #47

## Changes Made
- Replaced `columns: 300px` with `display: grid` and `grid-template-columns: repeat(3, 1fr)` in `.dashboard-grid`
- Replaced `column-span: all` with `grid-column: 1 / -1` on `.dashboard-hero` so House Health still spans full width
- Removed `margin-bottom` from grid children as `gap` handles spacing

## Testing
- [x] Tested locally with Docker
- [x] Tested on production-like environment

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have not committed any secrets (.env, API keys, passwords)

## Screenshots
<img width="1310" height="734" alt="image" src="https://github.com/user-attachments/assets/879dfa2c-38bf-4016-abf7-877023913ffa" />

## Additional Notes
The House Health hero card still correctly spans all 3 columns.  Responsive single column layout on mobile is preserved via the existing media query.