### PR TITLE
feat: add On Demand tasks, dashboard restructure, and card customisation

### DIFF
--- a/client/src/components/pages/Calendar.tsx
+++ b/client/src/components/pages/Calendar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from '../../hooks/useTranslation';
 
 interface CalendarProps {
   completions: Array<{ completedAt: string; taskName: string; translationKey?: string; roomName: string }>;
-  tasks: Array<{ id: number; name: string; translationKey?: string; roomName: string; roomType: string; health: number; frequencyDays: number; lastCompletedAt: string | null; iconKey?: string }>;
+  tasks: Array<{ id: number; name: string; translationKey?: string; roomName: string; roomType: string; health: number; frequencyDays: number; lastCompletedAt: string | null; iconKey?: string; onDemand?: boolean }>;
   language?: string;
 }
 
@@ -36,11 +36,11 @@ export function Calendar({ completions, tasks, language }: CalendarProps) {
         dueDate.setDate(dueDate.getDate() + task.frequencyDays);
       }
       const dueInDays = task.lastCompletedAt
-        ? Math.max(0, Math.ceil((dueDate.getTime() - Date.now()) / 86400000))
+        ? Math.max(0, Math.floor((dueDate.getTime() - Date.now()) / 86400000))
         : 0;
       return { ...task, dueInDays, dueDate };
     })
-    .filter((task) => task.dueInDays <= 30)
+    .filter((task) => !task.onDemand && task.dueInDays <= 30)
     .sort((a, b) => a.dueInDays - b.dueInDays);
 
   // Days with due tasks

--- a/client/src/components/pages/Dashboard.tsx
+++ b/client/src/components/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import HealthBar from '../shared/HealthBar';
 import RingGauge from '../shared/RingGauge';
 import UserAvatar from '../shared/UserAvatar';
@@ -36,6 +36,7 @@ interface Quest {
   roomAccent: string;
   lastCompletedAt: string | null;
   isSeasonal: boolean;
+  onDemand?: boolean;
   frequencyDays: number;
   dueDate?: string;
   dueInDays?: number;
@@ -85,12 +86,35 @@ interface FamilyMember {
   points: number;
 }
 
+interface CompletedTodayEntry {
+  completedAt: string;
+  coinsEarned: number;
+  taskId: number;
+  name: string;
+  translationKey?: string;
+  iconKey?: string;
+  roomId: number;
+  roomName: string;
+  roomType?: string;
+  roomColor: string;
+  roomAccent: string;
+  displayName: string;
+  avatarColor: string;
+  avatarType?: string;
+  avatarPreset?: string;
+  avatarPhotoUrl?: string;
+}
+
 interface DashboardProps {
   data: {
     houseHealth: number;
     rooms: Room[];
     todaysQuests: Quest[];
     nextTasks: Quest[];
+    readyToComplete?: Quest[];
+    scheduledUpcoming?: Quest[];
+    onDemandQuests?: Quest[];
+    completedToday?: CompletedTodayEntry[];
     myGoal?: { goalCoins: number; currentCoins: number; progress: number; goalStartAt?: string | null; goalEndAt?: string | null } | null;
     childrenGoals?: Array<{ id: number; displayName: string; role: string; coins: number; currentCoins?: number; goalCoins: number | null; progress: number | null; goalStartAt?: string | null; goalEndAt?: string | null }>;
     pendingRewardRequests?: Array<{ id: number; title: string; displayName: string; costCoins: number; redeemedAt: string; status: 'requested' | 'approved' | 'rejected' }>;
@@ -125,8 +149,50 @@ const Dashboard: React.FC<DashboardProps> = ({
   leaderboardPeriod = 'week',
 }) => {
   const { taskName, roomDisplayName, timeAgo, t } = useTranslation(language);
-  const { houseHealth, rooms, todaysQuests, nextTasks, myGoal, childrenGoals = [], pendingRewardRequests = [], currentUser, recentActivity } = data;
+  const { houseHealth, rooms, todaysQuests, nextTasks, readyToComplete, scheduledUpcoming, onDemandQuests, completedToday = [], myGoal, childrenGoals = [], pendingRewardRequests = [], currentUser, recentActivity } = data;
+  const readyTasks = readyToComplete ?? todaysQuests.filter(q => !q.onDemand);
+  const scheduledTasks = scheduledUpcoming ?? nextTasks;
+  const onDemandTasks = onDemandQuests ?? todaysQuests.filter(q => q.onDemand);
   const [adminModalQuest, setAdminModalQuest] = useState<Quest | null>(null);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [showCustomize, setShowCustomize] = useState(false);
+
+  const ALL_CARDS = [
+    { id: 'todaysQuests', label: t('dashboard.todaysQuests') },
+    { id: 'scheduled', label: t('dashboard.scheduled') },
+    { id: 'completedToday', label: t('dashboard.completedToday') },
+    { id: 'rooms', label: t('nav.rooms') },
+    { id: 'streak', label: t('dashboard.dayStreak') },
+    { id: 'coins', label: t('dashboard.coinsStatusTitle') },
+    { id: 'myGoal', label: t('dashboard.myGoal') },
+    { id: 'childrenGoals', label: t('dashboard.childrenGoals') },
+    { id: 'rewardRequests', label: t('dashboard.rewardRequestsTitle') },
+    { id: 'leaderboard', label: t('leaderboard.thisWeek') },
+    { id: 'recentActivity', label: t('dashboard.recentActivity') },
+  ];
+  const LS_KEY = 'tq-dashboard-cards';
+  const [hiddenCards, setHiddenCards] = useState<Set<string>>(() => {
+    try { return new Set(JSON.parse(localStorage.getItem(LS_KEY) || '[]')); }
+    catch { return new Set(); }
+  });
+  useEffect(() => {
+    localStorage.setItem(LS_KEY, JSON.stringify([...hiddenCards]));
+  }, [hiddenCards]);
+  const isVisible = (id: string) => !hiddenCards.has(id);
+  const toggleCard = (id: string) => setHiddenCards(prev => {
+    const next = new Set(prev);
+    next.has(id) ? next.delete(id) : next.add(id);
+    return next;
+  });
+  const LIMIT = 7;
+  const isExpanded = (key: string) => !!expanded[key];
+  const toggleExpand = (key: string) => setExpanded(p => ({ ...p, [key]: !p[key] }));
+  const showMoreBtn = (key: string, total: number) => total > LIMIT && (
+    <button className="tq-btn tq-btn-secondary" onClick={() => toggleExpand(key)}
+      style={{ marginTop: 8, width: '100%', fontSize: 12, padding: '8px' }}>
+      {isExpanded(key) ? t('common.showLess') : t('common.showMore').replace('{n}', `${total - LIMIT}`)}
+    </button>
+  );
   const sortedRooms = [...rooms].sort((a, b) => a.health - b.health);
   const roomTypeById = new Map(rooms.map((r) => [r.id, r.roomType]));
   const totalTasks = rooms.reduce((s, r) => s + r.taskCount, 0);
@@ -145,6 +211,27 @@ const Dashboard: React.FC<DashboardProps> = ({
 
   return (
     <>
+    {/* Customise panel */}
+    {showCustomize && (
+      <div style={{ position: 'fixed', inset: 0, zIndex: 1000, display: 'flex', alignItems: 'flex-end', justifyContent: 'flex-end' }}
+        onClick={(e) => { if (e.target === e.currentTarget) setShowCustomize(false); }}>
+        <div style={{ background: 'var(--warm-card)', border: '1.5px solid var(--warm-border)', borderRadius: 20, padding: 24, margin: 20, minWidth: 260, boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}>
+          <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)', marginBottom: 16 }}>{t('dashboard.customise')}</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {ALL_CARDS.map(card => (
+              <label key={card.id} style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}>
+                <input type="checkbox" checked={isVisible(card.id)} onChange={() => toggleCard(card.id)}
+                  style={{ width: 16, height: 16, accentColor: 'var(--warm-accent)', cursor: 'pointer' }} />
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--warm-text)' }}>{card.label}</span>
+              </label>
+            ))}
+          </div>
+          <button className="tq-btn tq-btn-secondary" onClick={() => setShowCustomize(false)}
+            style={{ marginTop: 16, width: '100%', fontSize: 12 }}>{t('common.cancel')}</button>
+        </div>
+      </div>
+    )}
+
     <div className="dashboard-grid">
 
         {/* House Health Card */}
@@ -159,6 +246,10 @@ const Dashboard: React.FC<DashboardProps> = ({
         >
           <RingGauge value={houseHealth} size={130} strokeWidth={11} />
           <div style={{ flex: 1 }}>
+          <button onClick={() => setShowCustomize(v => !v)} className="tq-btn tq-btn-secondary"
+            style={{ float: 'right', fontSize: 11, padding: '5px 10px', marginBottom: 6 }}>
+            ⚙ {t('dashboard.customise')}
+          </button>
             <div
               style={{
                 fontSize: 11,
@@ -211,37 +302,27 @@ const Dashboard: React.FC<DashboardProps> = ({
           </div>
         </div>
 
-        {/* Today's Quests Card */}
-        <div className="tq-card tq-card-padded">
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              marginBottom: 16,
-            }}
-          >
+        {/* Today's Quests Card — full width, sections: Ready to Complete / On Demand */}
+        {isVisible('todaysQuests') && <div className="tq-card tq-card-padded">
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
             <h3 style={{ fontSize: 16, fontWeight: 800, color: 'var(--warm-text)', margin: 0 }}>
               {t('dashboard.todaysQuests')}
             </h3>
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 800,
-                backgroundColor: 'var(--warm-badge-bg)',
-                color: 'var(--warm-badge-text)',
-                padding: '4px 12px',
-                borderRadius: 99,
-              }}
-            >
-              {todaysQuests.length} {t('dashboard.pending')}
+            <span style={{ fontSize: 11, fontWeight: 800, backgroundColor: 'var(--warm-badge-bg)', color: 'var(--warm-badge-text)', padding: '4px 12px', borderRadius: 99 }}>
+              {readyTasks.length + onDemandTasks.length} {t('dashboard.pending')}
             </span>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {todaysQuests.slice(0, 6).map((q) => {
+
+            {/* ── Ready to Complete ── */}
+            {readyTasks.length > 0 && (
+              <div style={{ fontSize: 11, fontWeight: 800, color: 'var(--warm-text-light)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 2 }}>
+                {t('dashboard.readyToComplete')}
+              </div>
+            )}
+            {(isExpanded('ready') ? readyTasks : readyTasks.slice(0, LIMIT)).map((q) => {
               const isAdminOrMember = currentUser.role === 'admin' || currentUser.role === 'member';
               const hasAssignees = (q.effectiveAssignedUserIds && q.effectiveAssignedUserIds.length > 0) || q.assignedToChildren;
-              // Determine done button state
               let btnDisabled = false;
               let btnLabel = t('roomDetail.done');
               if (q.assignmentMode === 'shared') {
@@ -256,147 +337,147 @@ const Dashboard: React.FC<DashboardProps> = ({
                   btnLabel = t('app.doneBy').replace('{name}', q.completedTodayBy.displayName);
                 }
               } else if (!isAdminOrMember) {
-                if (q.effectiveAssignedUserId !== null && q.effectiveAssignedUserId !== undefined) {
-                  if (q.effectiveAssignedUserId !== currentUser.id) {
-                    btnDisabled = true;
-                    btnLabel = t('app.notAssigned');
-                  }
+                if (q.effectiveAssignedUserId !== null && q.effectiveAssignedUserId !== undefined && q.effectiveAssignedUserId !== currentUser.id) {
+                  btnDisabled = true;
+                  btnLabel = t('app.notAssigned');
                 }
               }
-              const handleQuestDone = () => {
+              const handleDone = () => {
                 if (btnDisabled) return;
-                if (isAdminOrMember && hasAssignees) {
-                  setAdminModalQuest(q);
-                } else {
-                  onCompleteTask(q.id);
-                }
+                if (isAdminOrMember && hasAssignees) setAdminModalQuest(q);
+                else onCompleteTask(q.id);
               };
               return (
-                <div
-                  key={q.id}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 12,
-                    padding: '12px 14px',
-                    borderRadius: 16,
-                    backgroundColor: 'var(--warm-bg-subtle)',
-                    border: '1.5px solid var(--warm-border)',
-                    transition: 'all 0.3s ease',
-                  }}
-                >
-                  <div
-                    style={{
-                      width: 40,
-                      height: 40,
-                      borderRadius: 14,
-                      backgroundColor: q.roomColor,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flexShrink: 0,
-                      border: `1.5px solid ${q.roomAccent}44`,
-                    }}
-                  >
+                <div key={q.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', borderRadius: 16, backgroundColor: 'var(--warm-bg-subtle)', border: '1.5px solid var(--warm-border)' }}>
+                  <div style={{ width: 40, height: 40, borderRadius: 14, backgroundColor: q.roomColor, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, border: `1.5px solid ${q.roomAccent}44` }}>
                     <TaskIcon iconKey={q.iconKey} size={24} />
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--warm-text)' }}>
-                      {taskName(q.name, q.translationKey)}
-                    </div>
+                    <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--warm-text)' }}>{taskName(q.name, q.translationKey)}</div>
                     <div style={{ fontSize: 11, color: 'var(--warm-text-light)', fontWeight: 600 }}>
                       {roomDisplayName(q.roomName, roomTypeById.get(q.roomId) || '')}
                       {q.lastCompletedAt ? ` \u00B7 ${timeAgo(q.lastCompletedAt)}` : ''}
                     </div>
-                    <div style={{ marginTop: 5 }}>
-                      <HealthBar value={q.health} height={6} showLabel={false} />
-                    </div>
+                    <div style={{ marginTop: 5 }}><HealthBar value={q.health} height={6} showLabel={false} /></div>
                   </div>
-                  <button
-                    onClick={handleQuestDone}
-                    disabled={btnDisabled}
-                    className={btnDisabled ? 'tq-btn' : 'tq-btn tq-btn-primary'}
-                    style={{
-                      padding: '8px 14px',
-                      fontSize: 12,
-                      ...(btnDisabled ? {
-                        opacity: 0.55,
-                        cursor: 'default',
-                        backgroundColor: 'var(--warm-bg-subtle)',
-                        border: '1.5px solid var(--warm-border)',
-                        color: 'var(--warm-text-muted)',
-                        boxShadow: 'none',
-                      } : {
-                        backgroundColor: 'var(--warm-accent)',
-                        color: '#fff',
-                        boxShadow: '0 4px 14px var(--warm-primary-shadow)',
-                      }),
-                    }}
-                  >
+                  <button onClick={handleDone} disabled={btnDisabled} className={btnDisabled ? 'tq-btn' : 'tq-btn tq-btn-primary'}
+                    style={{ padding: '8px 14px', fontSize: 12, ...(btnDisabled ? { opacity: 0.55, cursor: 'default', backgroundColor: 'var(--warm-bg-subtle)', border: '1.5px solid var(--warm-border)', color: 'var(--warm-text-muted)', boxShadow: 'none' } : { backgroundColor: 'var(--warm-accent)', color: '#fff', boxShadow: '0 4px 14px var(--warm-primary-shadow)' }) }}>
                     {btnDisabled ? btnLabel : <><CheckIcon /> {btnLabel}</>}
                   </button>
                 </div>
               );
             })}
-            {todaysQuests.length === 0 && (
-              <div className="tq-empty-state" style={{ padding: '16px 4px' }}>
-                {t('dashboard.noQuests')}
-              </div>
+            {showMoreBtn('ready', readyTasks.length)}
+
+            {readyTasks.length === 0 && onDemandTasks.length === 0 && (
+              <div className="tq-empty-state" style={{ padding: '16px 4px' }}>{t('dashboard.noQuests')}</div>
+            )}
+
+            {/* ── On Demand ── */}
+            {onDemandTasks.length > 0 && (
+              <>
+                <div style={{ fontSize: 11, fontWeight: 800, color: 'var(--warm-text-light)', textTransform: 'uppercase', letterSpacing: '0.05em', marginTop: readyTasks.length > 0 ? 10 : 2, marginBottom: 2 }}>
+                  {t('dashboard.onDemand')}
+                </div>
+                {(isExpanded('ondemand') ? onDemandTasks : onDemandTasks.slice(0, LIMIT)).map((q) => {
+                  const isAdminOrMember = currentUser.role === 'admin' || currentUser.role === 'member';
+                  const hasAssignees = (q.effectiveAssignedUserIds && q.effectiveAssignedUserIds.length > 0) || q.assignedToChildren;
+                  const handleDone = () => {
+                    if (isAdminOrMember && hasAssignees) setAdminModalQuest(q);
+                    else onCompleteTask(q.id);
+                  };
+                  return (
+                    <div key={q.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', borderRadius: 16, backgroundColor: 'var(--warm-bg-subtle)', border: '1.5px solid var(--warm-border)' }}>
+                      <div style={{ width: 40, height: 40, borderRadius: 14, backgroundColor: q.roomColor, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, border: `1.5px solid ${q.roomAccent}44` }}>
+                        <TaskIcon iconKey={q.iconKey} size={24} />
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--warm-text)' }}>{taskName(q.name, q.translationKey)}</div>
+                        <div style={{ fontSize: 11, color: 'var(--warm-text-light)', fontWeight: 600 }}>
+                          {roomDisplayName(q.roomName, roomTypeById.get(q.roomId) || '')}
+                          {q.lastCompletedAt ? ` \u00B7 ${timeAgo(q.lastCompletedAt)}` : ''}
+                        </div>
+                      </div>
+                      <button onClick={handleDone} className="tq-btn tq-btn-primary" style={{ padding: '8px 14px', fontSize: 12, backgroundColor: 'var(--warm-accent)', color: '#fff', boxShadow: '0 4px 14px var(--warm-primary-shadow)' }}>
+                        <CheckIcon /> {t('roomDetail.done')}
+                      </button>
+                    </div>
+                  );
+                })}
+                {showMoreBtn('ondemand', onDemandTasks.length)}
+              </>
             )}
           </div>
-        </div>
+        </div>}
 
-        {/* Next Tasks Card */}
-        <div className="tq-card tq-card-padded">
-          <h3 style={{ fontSize: 16, fontWeight: 800, color: 'var(--warm-text)', margin: '0 0 12px' }}>
-            {t('dashboard.nextTasks')}
-          </h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {nextTasks.slice(0, 6).map((q) => {
-              return (
-                <div key={q.id} style={{
-                  display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px',
-                  borderRadius: 14, backgroundColor: 'var(--warm-bg-subtle)', border: '1.5px solid var(--warm-border)',
-                }}>
-                  <div style={{
-                    width: 34, height: 34, borderRadius: 12, backgroundColor: q.roomColor,
-                    display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-                    border: `1.5px solid ${q.roomAccent}44`,
-                  }}><TaskIcon iconKey={q.iconKey} size={20} /></div>
+        {/* Scheduled Card — upcoming tasks not yet due */}
+        {isVisible('scheduled') && scheduledTasks.length > 0 && (
+          <div className="tq-card tq-card-padded">
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+              <h3 style={{ fontSize: 16, fontWeight: 800, color: 'var(--warm-text)', margin: 0 }}>
+                {t('dashboard.scheduled')}
+              </h3>
+              <span style={{ fontSize: 11, fontWeight: 800, backgroundColor: 'var(--warm-badge-bg)', color: 'var(--warm-badge-text)', padding: '4px 12px', borderRadius: 99 }}>
+                {scheduledTasks.length}
+              </span>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {(isExpanded('scheduled') ? scheduledTasks : scheduledTasks.slice(0, LIMIT)).map((q) => (
+                <div key={q.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', borderRadius: 14, backgroundColor: 'var(--warm-bg-subtle)', border: '1.5px solid var(--warm-border)' }}>
+                  <div style={{ width: 34, height: 34, borderRadius: 12, backgroundColor: q.roomColor, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, border: `1.5px solid ${q.roomAccent}44` }}>
+                    <TaskIcon iconKey={q.iconKey} size={20} />
+                  </div>
                   <div style={{ flex: 1 }}>
                     <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--warm-text)' }}>{taskName(q.name, q.translationKey)}</div>
-                    <div style={{ fontSize: 10, color: 'var(--warm-text-light)', fontWeight: 600 }}>
-                      {roomDisplayName(q.roomName, roomTypeById.get(q.roomId) || '')}
-                    </div>
+                    <div style={{ fontSize: 10, color: 'var(--warm-text-light)', fontWeight: 600 }}>{roomDisplayName(q.roomName, roomTypeById.get(q.roomId) || '')}</div>
                   </div>
                   <div style={{ fontSize: 11, fontWeight: 800, color: 'var(--warm-streak-subtext)', backgroundColor: 'var(--warm-accent-light)', border: '1px solid var(--warm-streak-border)', borderRadius: 999, padding: '3px 8px' }}>
-                    {(q.dueInDays ?? 0) <= 0
-                      ? t('calendar.today')
-                      : (q.dueInDays === 1)
-                        ? t('calendar.tomorrow')
-                        : t('calendar.inDays').replace('{days}', `${q.dueInDays}`)}
+                    {(q.dueInDays ?? 0) <= 0 ? t('calendar.today') : q.dueInDays === 1 ? t('calendar.tomorrow') : t('calendar.inDays').replace('{days}', `${q.dueInDays}`)}
                   </div>
                 </div>
-              );
-            })}
-            {nextTasks.length === 0 && (
-              <div className="tq-empty-state" style={{ padding: '16px 4px' }}>
-                {t('calendar.allCaughtUp')}
-              </div>
-            )}
+              ))}
+              {showMoreBtn('scheduled', scheduledTasks.length)}
+            </div>
           </div>
-        </div>
+        )}
+
+        {/* Completed Today Card */}
+        {isVisible('completedToday') && completedToday.length > 0 && (
+          <div className="tq-card tq-card-padded">
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+              <h3 style={{ fontSize: 16, fontWeight: 800, color: 'var(--warm-text)', margin: 0 }}>
+                {t('dashboard.completedToday')}
+              </h3>
+              <span style={{ fontSize: 11, fontWeight: 800, backgroundColor: 'var(--warm-badge-bg)', color: 'var(--warm-badge-text)', padding: '4px 12px', borderRadius: 99 }}>
+                {completedToday.length}
+              </span>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {(isExpanded('completed') ? completedToday : completedToday.slice(0, LIMIT)).map((c, i) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', borderRadius: 14, backgroundColor: 'var(--warm-bg-subtle)', border: '1.5px solid var(--warm-border)' }}>
+                  <div style={{ width: 34, height: 34, borderRadius: 12, backgroundColor: c.roomColor, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, border: `1.5px solid ${c.roomAccent}44` }}>
+                    <TaskIcon iconKey={c.iconKey} size={20} />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--warm-text)' }}>{taskName(c.name, c.translationKey)}</div>
+                    <div style={{ fontSize: 10, color: 'var(--warm-text-light)', fontWeight: 600 }}>
+                      {roomDisplayName(c.roomName, c.roomType || '')} &middot; {c.displayName}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 3, fontSize: 11, fontWeight: 800, color: 'var(--warm-accent)' }}>
+                    {gamificationEnabled && <><CoinIcon /> +{c.coinsEarned}</>}
+                    <CheckIcon />
+                  </div>
+                </div>
+              ))}
+              {showMoreBtn('completed', completedToday.length)}
+            </div>
+          </div>
+        )}
 
       {/* ── Rooms ── */}
-      <div className="tq-card tq-card-padded">
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            marginBottom: 16,
-          }}
-        >
+      {isVisible('rooms') && <div className="tq-card tq-card-padded">
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
           <h3 style={{ fontSize: 16, fontWeight: 800, color: 'var(--warm-text)', margin: 0 }}>
             {t('nav.rooms')}
           </h3>
@@ -405,7 +486,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           </span>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {sortedRooms.map((room) => {
+          {(isExpanded('rooms') ? sortedRooms : sortedRooms.slice(0, LIMIT)).map((room) => {
             const RoomIcon = getRoomIcon(room.roomType || room.name);
             return (
               <div
@@ -466,12 +547,13 @@ const Dashboard: React.FC<DashboardProps> = ({
               </div>
             );
           })}
+          {showMoreBtn('rooms', sortedRooms.length)}
         </div>
-      </div>
+      </div>}
 
       {/* ── Widgets ── */}
         {/* Streak Card */}
-        {gamificationEnabled && <div
+        {gamificationEnabled && isVisible('streak') && <div
           className="tq-card tq-card-padded"
           style={{
             background: 'var(--warm-streak-bg)',
@@ -544,7 +626,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           </div>
         </div>}
 
-        {gamificationEnabled && <div className="tq-card tq-card-padded">
+        {gamificationEnabled && isVisible('coins') && <div className="tq-card tq-card-padded">
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
             <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)' }}>{t('dashboard.coinsStatusTitle')}</div>
             <span style={{ fontSize: 10, fontWeight: 800, borderRadius: 999, padding: '3px 8px', backgroundColor: 'var(--warm-accent-light)', color: 'var(--warm-accent)', border: '1px solid var(--warm-accent)' }}>
@@ -564,7 +646,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           </div>
         </div>}
 
-        {gamificationEnabled && myGoal && (
+        {gamificationEnabled && isVisible('myGoal') && myGoal && (
           <div className="tq-card tq-card-padded">
             <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)', marginBottom: 6 }}>{t('dashboard.myGoal')}</div>
             <div style={{ fontSize: 12, color: 'var(--warm-text-muted)', fontWeight: 700, marginBottom: 8 }}>
@@ -579,7 +661,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           </div>
         )}
 
-        {gamificationEnabled && currentUser.role === 'admin' && childrenGoals.length > 0 && (
+        {gamificationEnabled && isVisible('childrenGoals') && currentUser.role === 'admin' && childrenGoals.length > 0 && (
           <div className="tq-card tq-card-padded">
             <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)', marginBottom: 8 }}>{t('dashboard.childrenGoals')}</div>
             <div style={{ display: 'grid', gap: 8 }}>
@@ -601,7 +683,7 @@ const Dashboard: React.FC<DashboardProps> = ({
           </div>
         )}
 
-        {gamificationEnabled && currentUser.role === 'admin' && (
+        {gamificationEnabled && isVisible('rewardRequests') && currentUser.role === 'admin' && (
           <div className="tq-card tq-card-padded">
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
               <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)' }}>{t('dashboard.rewardRequestsTitle')}</div>
@@ -642,7 +724,7 @@ const Dashboard: React.FC<DashboardProps> = ({
         )}
 
         {/* Mini Leaderboard */}
-        {gamificationEnabled && <div className="tq-card tq-card-padded">
+        {gamificationEnabled && isVisible('leaderboard') && <div className="tq-card tq-card-padded">
           <h3
             style={{
               fontSize: 14,
@@ -704,7 +786,7 @@ const Dashboard: React.FC<DashboardProps> = ({
         </div>}
 
         {/* Recent Activity */}
-        <div className="tq-card tq-card-padded">
+        {isVisible('recentActivity') && <div className="tq-card tq-card-padded">
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
             <h3
               style={{
@@ -761,7 +843,7 @@ const Dashboard: React.FC<DashboardProps> = ({
               </div>}
             </div>
           ))}
-        </div>
+        </div>}
     </div>
     {adminModalQuest && (
       <AdminCompleteModal

--- a/client/src/components/pages/RoomDetail.tsx
+++ b/client/src/components/pages/RoomDetail.tsx
@@ -96,7 +96,7 @@ interface CompletedTodayBy {
 
 interface Task {
   id: number; name: string; translationKey?: string; health: number; frequencyDays: number;
-  effort: number; notes?: string | null; isSeasonal: boolean; lastCompletedAt: string | null; iconKey?: string;
+  effort: number; notes?: string | null; isSeasonal: boolean; onDemand?: boolean; showInDashboard?: boolean; lastCompletedAt: string | null; iconKey?: string;
   assignedToChildren?: boolean;
   assignedUserIds?: number[];
   assignedUsers?: Array<{ id: number; displayName: string; avatarColor: string; avatarType?: string; avatarPreset?: string; avatarPhotoUrl?: string; coinPercentage?: number }>;
@@ -170,7 +170,7 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
   const { taskName: translateTask, roomDisplayName, timeAgo, t } = useTranslation(language);
   const [animatedTask, setAnimatedTask] = useState<number | null>(null);
   const [editingTask, setEditingTask] = useState<number | null>(null);
-  const [editForm, setEditForm] = useState({ name: '', notes: '', freqValue: 7, freqUnit: 'days', effort: 1, health: 100, iconKey: 'sparkle', assignmentType: 'none' as 'none' | 'users', assignmentUserIds: [] as number[], assignmentMode: 'first' as 'first' | 'shared' | 'custom', assignmentPercentages: {} as Record<number, number> });
+  const [editForm, setEditForm] = useState({ name: '', notes: '', freqValue: 7, freqUnit: 'days', effort: 1, health: 100, iconKey: 'sparkle', onDemand: false, showInDashboard: false, assignmentType: 'none' as 'none' | 'users', assignmentUserIds: [] as number[], assignmentMode: 'first' as 'first' | 'shared' | 'custom', assignmentPercentages: {} as Record<number, number> });
   const [showAddTask, setShowAddTask] = useState(false);
   const [newTaskName, setNewTaskName] = useState('');
   const [newTaskNotes, setNewTaskNotes] = useState('');
@@ -183,6 +183,8 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
   const [newAssignmentUserIds, setNewAssignmentUserIds] = useState<number[]>([]);
   const [newAssignmentMode, setNewAssignmentMode] = useState<'first' | 'shared' | 'custom'>('first');
   const [newAssignmentPercentages, setNewAssignmentPercentages] = useState<Record<number, number>>({});
+  const [newTaskOnDemand, setNewTaskOnDemand] = useState(false);
+  const [newTaskShowInDashboard, setNewTaskShowInDashboard] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>('health');
   const [sortAsc, setSortAsc] = useState(true);
 
@@ -262,7 +264,7 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
       assignmentPercentages[u.id] = u.coinPercentage ?? 0;
     }
     setEditingTask(task.id);
-    setEditForm({ name: task.name, notes: task.notes || '', freqValue: value, freqUnit: unit, effort: task.effort, health: task.health, iconKey: task.iconKey || 'sparkle', assignmentType, assignmentUserIds, assignmentMode: task.assignmentMode || 'first', assignmentPercentages });
+    setEditForm({ name: task.name, notes: task.notes || '', freqValue: value, freqUnit: unit, effort: task.effort, health: task.health, iconKey: task.iconKey || 'sparkle', onDemand: !!task.onDemand, showInDashboard: !!task.showInDashboard, assignmentType, assignmentUserIds, assignmentMode: task.assignmentMode || 'first', assignmentPercentages });
   };
 
   const saveEdit = async () => {
@@ -272,7 +274,7 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
       editForm.assignmentType === 'users' ? { assignedToChildren: false, assignedUserIds: editForm.assignmentUserIds } :
       { assignedToChildren: false, assignedUserIds: [] };
     const assignedUserPercentages = editForm.assignmentMode === 'custom' ? editForm.assignmentPercentages : undefined;
-    await api.updateTask(editingTask, { name: editForm.name, notes: editForm.notes, frequencyDays, effort: editForm.effort, health: editForm.health, iconKey: editForm.iconKey, assignmentMode: editForm.assignmentMode, assignedUserPercentages, ...assignmentPayload });
+    await api.updateTask(editingTask, { name: editForm.name, notes: editForm.notes, frequencyDays, effort: editForm.effort, health: editForm.health, iconKey: editForm.iconKey, onDemand: editForm.onDemand, showInDashboard: editForm.showInDashboard, assignmentMode: editForm.assignmentMode, assignedUserPercentages, ...assignmentPayload });
     setEditingTask(null);
     onRefresh?.();
   };
@@ -286,6 +288,11 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
           return { disabled: true, label: t('app.notAssigned') };
         }
       }
+    }
+
+    // On-demand tasks are always completeable — skip all scheduling and repetition guards
+    if (task.onDemand) {
+      return { disabled: false, label: t('roomDetail.done') };
     }
 
     // Block if task frequency cooldown hasn't elapsed (health > 0 means not yet due)
@@ -335,6 +342,8 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
       effort: newTaskEffort,
       health: newTaskHealth,
       iconKey: newTaskIconKey,
+      onDemand: newTaskOnDemand,
+      showInDashboard: newTaskShowInDashboard,
       assignmentMode: newAssignmentMode,
       assignedUserPercentages,
       ...assignmentPayload,
@@ -350,6 +359,8 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
     setNewAssignmentUserIds([]);
     setNewAssignmentMode('first');
     setNewAssignmentPercentages({});
+    setNewTaskOnDemand(false);
+    setNewTaskShowInDashboard(false);
     setShowAddTask(false);
     onRefresh?.();
   };
@@ -426,11 +437,23 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
                   </div>
                   <div className="task-edit-form" style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.onDemand')}</label>
+                      <input type="checkbox" checked={editForm.onDemand}
+                        onChange={(e) => setEditForm(f => ({ ...f, onDemand: e.target.checked }))}
+                        style={{ cursor: 'pointer', width: 16, height: 16, accentColor: 'var(--warm-accent)' }} />
+                    </div>
+                    {editForm.onDemand && <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.showInDashboard')}</label>
+                      <input type="checkbox" checked={editForm.showInDashboard}
+                        onChange={(e) => setEditForm(f => ({ ...f, showInDashboard: e.target.checked }))}
+                        style={{ cursor: 'pointer', width: 16, height: 16, accentColor: 'var(--warm-accent)' }} />
+                    </div>}
+                    {!editForm.onDemand && <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                       <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.every')}</label>
                       <FrequencyPicker value={editForm.freqValue} unit={editForm.freqUnit}
                         t={t}
                         onChange={(v, u) => setEditForm(f => ({ ...f, freqValue: v, freqUnit: u }))} />
-                    </div>
+                    </div>}
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                       <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.effort')}</label>
                       <EffortPicker effort={editForm.effort} onChange={(e) => setEditForm(f => ({ ...f, effort: e }))} />
@@ -634,19 +657,27 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
                       </div>
                     )}
                     <div style={{ fontSize: 11, color: 'var(--warm-text-light)', fontWeight: 600 }}>
-                      {timeAgo(task.lastCompletedAt)}{task.isSeasonal ? ` · ${t('roomDetail.seasonal')}` : ''}
+                      {timeAgo(task.lastCompletedAt)}{task.isSeasonal ? ` · ${t('roomDetail.seasonal')}` : ''}{task.onDemand ? ` · ${t('roomDetail.onDemand')}` : ''}
                     </div>
                   </div>
                 </div>
                 <div className="room-task-health"><HealthBar value={animatedTask === task.id ? 100 : task.health} height={8} animate={animatedTask === task.id} /></div>
-                <div className="room-task-frequency" style={{ fontSize: 13, color: 'var(--warm-text-secondary)', fontWeight: 600 }}>{t('roomDetail.every')} {formatFreq(task.frequencyDays, t)}</div>
+                <div className="room-task-frequency" style={{ fontSize: 13, color: 'var(--warm-text-secondary)', fontWeight: 600 }}>
+                  {task.onDemand
+                    ? <span style={{ color: 'var(--warm-accent)', fontWeight: 700 }}>{t('roomDetail.onDemand')}</span>
+                    : <>{t('roomDetail.every')} {formatFreq(task.frequencyDays, t)}</>
+                  }
+                </div>
                 <div className="room-task-effort"><EffortDots effort={task.effort} /></div>
                 <div className="room-task-coins" style={{ fontSize: 12, fontWeight: 800, color: 'var(--warm-accent)', display: 'flex', alignItems: 'center', gap: 3 }}>
                   <CoinIcon />{coinsByEffort?.[task.effort] ?? task.effort * 5}
                 </div>
-                {(() => { const { text, color } = formatNextDue(task.lastCompletedAt, task.frequencyDays, t, language); return (
-                  <div className="room-task-due" style={{ fontSize: 12, fontWeight: 700, color }}>{text}</div>
-                ); })()}
+                {task.onDemand
+                  ? <div className="room-task-due" style={{ fontSize: 12, fontWeight: 700, color: 'var(--warm-text-light)' }}>—</div>
+                  : (() => { const { text, color } = formatNextDue(task.lastCompletedAt, task.frequencyDays, t, language); return (
+                      <div className="room-task-due" style={{ fontSize: 12, fontWeight: 700, color }}>{text}</div>
+                    ); })()
+                }
                 <div className="room-task-assigned" style={{ fontSize: 12, color: 'var(--warm-text-secondary)', fontWeight: 600 }}>
                   {task.assignedUsers && task.assignedUsers.length > 0
                     ? <span>
@@ -757,11 +788,23 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
               </div>
               <div className="task-add-form" style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.onDemand')}</label>
+                  <input type="checkbox" checked={newTaskOnDemand}
+                    onChange={(e) => setNewTaskOnDemand(e.target.checked)}
+                    style={{ cursor: 'pointer', width: 16, height: 16, accentColor: 'var(--warm-accent)' }} />
+                </div>
+                {newTaskOnDemand && <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.showInDashboard')}</label>
+                  <input type="checkbox" checked={newTaskShowInDashboard}
+                    onChange={(e) => setNewTaskShowInDashboard(e.target.checked)}
+                    style={{ cursor: 'pointer', width: 16, height: 16, accentColor: 'var(--warm-accent)' }} />
+                </div>}
+                {!newTaskOnDemand && <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                   <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.every')}</label>
                   <FrequencyPicker value={newFreqValue} unit={newFreqUnit}
                     t={t}
                     onChange={(v, u) => { setNewFreqValue(v); setNewFreqUnit(u); }} />
-                </div>
+                </div>}
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                   <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.effort')}</label>
                   <EffortPicker effort={newTaskEffort} onChange={setNewTaskEffort} />

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -59,7 +59,7 @@ export const api = {
 
   // Tasks
   getTasks: (roomId: number) => apiFetch<any[]>(`/rooms/${roomId}/tasks`),
-  createTask: (roomId: number, data: { name: string; notes?: string; frequencyDays?: number; effort?: number; isSeasonal?: boolean; health?: number; iconKey?: string; assignedToChildren?: boolean; assignedUserIds?: number[]; assignmentMode?: 'first' | 'shared' | 'custom'; assignedUserPercentages?: Record<number, number> }) =>
+  createTask: (roomId: number, data: { name: string; notes?: string; frequencyDays?: number; effort?: number; isSeasonal?: boolean; health?: number; iconKey?: string; onDemand?: boolean; showInDashboard?: boolean; assignedToChildren?: boolean; assignedUserIds?: number[]; assignmentMode?: 'first' | 'shared' | 'custom'; assignedUserPercentages?: Record<number, number> }) =>
     apiFetch<any>(`/rooms/${roomId}/tasks`, { method: 'POST', body: JSON.stringify(data) }),
   updateTask: (id: number, data: any) =>
     apiFetch<any>(`/tasks/${id}`, { method: 'PUT', body: JSON.stringify(data) }),

--- a/client/src/i18n/de.json
+++ b/client/src/i18n/de.json
@@ -407,6 +407,8 @@
       "done": "Erledigt",
       "assignToChildren": "Der Kindergruppe zuweisen",
       "seasonal": "Saisonal",
+      "onDemand": "Auf Abruf",
+      "showInDashboard": "Im Dashboard anzeigen",
       "taskName": "Aufgabenname...",
       "addTask": "Aufgabe hinzufügen",
       "icon": "Symbol",
@@ -435,7 +437,12 @@
     "dashboard": {
       "houseHealth": "Hauszustand",
       "todaysQuests": "Heutige Aufgaben",
+      "readyToComplete": "Bereit zum Erledigen",
+      "scheduled": "Geplant",
+      "onDemand": "Auf Abruf",
+      "completedToday": "Heute erledigt",
       "recentActivity": "Letzte Aktivitäten",
+      "customise": "Anpassen",
       "noQuests": "Keine Aufgaben für heute",
       "roomsCount": "Räume",
       "tasksCount": "Aufgaben",
@@ -507,7 +514,9 @@
       "edit": "Bearbeiten",
       "loading": "Laden",
       "add": "Hinzufügen",
-      "you": "Sie"
+      "you": "Sie",
+      "showMore": "{n} mehr anzeigen",
+      "showLess": "Weniger anzeigen"
     },
     "units": {
       "hours": "Stunden",

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -407,6 +407,8 @@
       "done": "Done",
       "assignToChildren": "Assign to Children group",
       "seasonal": "Seasonal",
+      "onDemand": "On Demand",
+      "showInDashboard": "Show in Dashboard",
       "taskName": "Task name...",
       "addTask": "Add Task",
       "icon": "Icon",
@@ -435,7 +437,12 @@
     "dashboard": {
       "houseHealth": "House Health",
       "todaysQuests": "Today's Quests",
+      "readyToComplete": "Ready to Complete",
+      "scheduled": "Scheduled",
+      "onDemand": "On Demand",
+      "completedToday": "Completed Today",
       "recentActivity": "Recent Activity",
+      "customise": "Customise",
       "noQuests": "No quests for today",
       "roomsCount": "Rooms",
       "tasksCount": "Tasks",
@@ -507,7 +514,9 @@
       "edit": "Edit",
       "loading": "Loading",
       "add": "Add",
-      "you": "You"
+      "you": "You",
+      "showMore": "Show {n} more",
+      "showLess": "Show less"
     },
     "units": {
       "hours": "hours",

--- a/client/src/i18n/es.json
+++ b/client/src/i18n/es.json
@@ -407,6 +407,8 @@
       "done": "Hecho",
       "assignToChildren": "Asignar al grupo de niños",
       "seasonal": "Estacional",
+      "onDemand": "A demanda",
+      "showInDashboard": "Mostrar en el panel",
       "taskName": "Nombre de la tarea...",
       "addTask": "Añadir tarea",
       "icon": "Icono",
@@ -435,7 +437,12 @@
     "dashboard": {
       "houseHealth": "Salud del hogar",
       "todaysQuests": "Misiones de hoy",
+      "readyToComplete": "Listas para completar",
+      "scheduled": "Programadas",
+      "onDemand": "A demanda",
+      "completedToday": "Completadas hoy",
       "recentActivity": "Actividad reciente",
+      "customise": "Personalizar",
       "noQuests": "No hay misiones para hoy",
       "roomsCount": "Habitaciones",
       "tasksCount": "Tareas",
@@ -507,7 +514,9 @@
       "edit": "Editar",
       "loading": "Cargando",
       "add": "Añadir",
-      "you": "tú"
+      "you": "tú",
+      "showMore": "Mostrar {n} más",
+      "showLess": "Mostrar menos"
     },
     "units": {
       "hours": "horas",

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -407,6 +407,8 @@
       "done": "Fait",
       "assignToChildren": "Attribuer au groupe enfants",
       "seasonal": "Saisonnier",
+      "onDemand": "À la demande",
+      "showInDashboard": "Afficher dans le tableau de bord",
       "taskName": "Nom de la tâche...",
       "addTask": "Ajouter une tâche",
       "icon": "Icône",
@@ -435,7 +437,12 @@
     "dashboard": {
       "houseHealth": "Santé de la maison",
       "todaysQuests": "Quêtes du jour",
+      "readyToComplete": "Prêtes à compléter",
+      "scheduled": "Planifiées",
+      "onDemand": "À la demande",
+      "completedToday": "Complétées aujourd'hui",
       "recentActivity": "Activité récente",
+      "customise": "Personnaliser",
       "noQuests": "Aucune quête pour aujourd'hui",
       "roomsCount": "Pièces",
       "tasksCount": "Tâches",
@@ -507,7 +514,9 @@
       "edit": "Modifier",
       "loading": "Chargement",
       "add": "Ajouter",
-      "you": "vous"
+      "you": "vous",
+      "showMore": "Afficher {n} de plus",
+      "showLess": "Afficher moins"
     },
     "units": {
       "hours": "heures",

--- a/client/src/i18n/it.json
+++ b/client/src/i18n/it.json
@@ -407,6 +407,8 @@
       "done": "Fatto",
       "assignToChildren": "Assegna al gruppo bambini",
       "seasonal": "Stagionale",
+      "onDemand": "Su richiesta",
+      "showInDashboard": "Mostra nella dashboard",
       "taskName": "Nome attività...",
       "addTask": "Aggiungi attività",
       "icon": "Icona",
@@ -435,7 +437,12 @@
     "dashboard": {
       "houseHealth": "Stato della casa",
       "todaysQuests": "Missioni di oggi",
+      "readyToComplete": "Pronte da completare",
+      "scheduled": "Programmate",
+      "onDemand": "Su richiesta",
+      "completedToday": "Completate oggi",
       "recentActivity": "Attività recenti",
+      "customise": "Personalizza",
       "noQuests": "Nessuna missione per oggi",
       "roomsCount": "Stanze",
       "tasksCount": "Attività",
@@ -507,7 +514,9 @@
       "edit": "Modifica",
       "loading": "Caricamento",
       "add": "Aggiungi",
-      "you": "tu"
+      "you": "tu",
+      "showMore": "Mostra altri {n}",
+      "showLess": "Mostra meno"
     },
     "units": {
       "hours": "ore",

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -188,6 +188,8 @@ export function initDatabase() {
     `ALTER TABLE task_completions ADD COLUMN approvedByUserId INTEGER REFERENCES users(id) ON DELETE SET NULL`,
     `ALTER TABLE task_completions ADD COLUMN approvedAt TEXT`,
     `ALTER TABLE users ADD COLUMN vacationEndDate TEXT`,
+    `ALTER TABLE tasks ADD COLUMN onDemand INTEGER NOT NULL DEFAULT 0`,
+    `ALTER TABLE tasks ADD COLUMN showInDashboard INTEGER NOT NULL DEFAULT 0`,
   ];
 
   for (const sql of migrations) {

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -71,7 +71,7 @@ router.get('/', (req: AuthRequest, res: Response) => {
       const dueDateTs = t.lastCompletedAt
         ? new Date(t.lastCompletedAt).getTime() + safeFreq * 86400000
         : nowTs;
-      const dueInDays = Math.max(0, Math.floor((dueDateTs - nowTs) / 86400000));
+      const dueInDays = t.onDemand ? 0 : Math.max(0, Math.floor((dueDateTs - nowTs) / 86400000));
       const taskWithHealth = {
         ...t,
         isSeasonal: !!t.isSeasonal,
@@ -116,17 +116,41 @@ router.get('/', (req: AuthRequest, res: Response) => {
     ? Math.round(forHouseAvg.reduce((s, t) => s + t.health * t.effort, 0) / totalEffort)
     : 100;
 
-  // Today's quests: tasks due today or overdue, non-seasonal
-  const todaysQuests = allTasks
-    .filter((t) => !t.isSeasonal && t.dueInDays <= 0)
+  // Ready to complete: actually overdue (due date has passed), non-seasonal, non-on-demand
+  const readyToComplete = allTasks
+    .filter((t) => !t.isSeasonal && !t.onDemand && new Date(t.dueDate).getTime() <= nowTs)
+    .sort((a, b) => a.health - b.health)
+    .slice(0, 10);
+
+  // Scheduled upcoming: not yet due (due date in the future), non-seasonal, non-on-demand
+  const scheduledUpcoming = allTasks
+    .filter((t) => !t.isSeasonal && !t.onDemand && new Date(t.dueDate).getTime() > nowTs)
     .sort((a, b) => a.dueInDays - b.dueInDays || a.health - b.health)
     .slice(0, 10);
 
-  // Next tasks to come soon (non-seasonal)
-  const nextTasks = allTasks
-    .filter((t) => !t.isSeasonal && t.dueInDays > 0)
-    .sort((a, b) => a.dueInDays - b.dueInDays || a.health - b.health)
-    .slice(0, 10);
+  // On-demand quests: only those opted in via showInDashboard
+  const onDemandQuests = allTasks
+    .filter((t) => !t.isSeasonal && t.onDemand && t.showInDashboard)
+    .sort((a, b) => a.health - b.health);
+
+  // Backwards-compatible aliases
+  const todaysQuests = [...readyToComplete, ...onDemandQuests];
+  const nextTasks = scheduledUpcoming;
+
+  // Completed today
+  const completedToday = db.prepare(`
+    SELECT tc.completedAt, tc.coinsEarned,
+           t.id as taskId, t.name, t.translationKey, t.iconKey, t.roomId,
+           r.name as roomName, r.roomType, r.color as roomColor, r.accentColor as roomAccent,
+           u.displayName, u.avatarColor, u.avatarType, u.avatarPreset, u.avatarPhotoUrl
+    FROM task_completions tc
+    JOIN tasks t ON tc.taskId = t.id
+    JOIN rooms r ON t.roomId = r.id
+    JOIN users u ON tc.userId = u.id
+    WHERE tc.status = 'approved'
+      AND date(tc.completedAt, 'localtime') = date('now', 'localtime')
+    ORDER BY tc.completedAt DESC
+  `).all();
 
   // Recent activity
   const recentActivity = db.prepare(`
@@ -188,7 +212,11 @@ router.get('/', (req: AuthRequest, res: Response) => {
     houseHealth,
     rooms: roomsWithHealth,
     todaysQuests,
+    readyToComplete,
+    scheduledUpcoming,
+    onDemandQuests,
     nextTasks,
+    completedToday,
     myGoal,
     childrenGoals,
     pendingRewardRequests,

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -198,7 +198,7 @@ router.post('/rooms/:roomId/tasks', (req: AuthRequest, res: Response) => {
     return res.status(403).json({ error: 'Admin only' });
   }
 
-  const { name, notes, frequencyDays, effort, isSeasonal, health, iconKey, assignedToChildren, assignedUserIds, assignmentMode, assignedUserPercentages } = req.body;
+  const { name, notes, frequencyDays, effort, isSeasonal, health, iconKey, assignedToChildren, assignedUserIds, assignmentMode, assignedUserPercentages, onDemand, showInDashboard } = req.body;
   if (!name) return res.status(400).json({ error: 'name is required' });
 
   const room = db.prepare('SELECT id FROM rooms WHERE id = ?').get(req.params.roomId);
@@ -227,8 +227,8 @@ router.post('/rooms/:roomId/tasks', (req: AuthRequest, res: Response) => {
   }
 
   const result = db.prepare(
-    'INSERT INTO tasks (roomId, name, notes, frequencyDays, effort, isSeasonal, lastCompletedAt, iconKey, assignedToChildren, assignmentMode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
-  ).run(req.params.roomId, name, notes || null, frequencyDays || 7, effort || 1, isSeasonal ? 1 : 0, lastCompletedAt, iconKey || suggestTaskIcon(name, null), resolvedAssignedToChildren, resolvedAssignmentMode);
+    'INSERT INTO tasks (roomId, name, notes, frequencyDays, effort, isSeasonal, lastCompletedAt, iconKey, assignedToChildren, assignmentMode, onDemand, showInDashboard) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run(req.params.roomId, name, notes || null, frequencyDays || 7, effort || 1, isSeasonal ? 1 : 0, lastCompletedAt, iconKey || suggestTaskIcon(name, null), resolvedAssignedToChildren, resolvedAssignmentMode, onDemand ? 1 : 0, showInDashboard ? 1 : 0);
 
   const newTaskId = result.lastInsertRowid as number;
 
@@ -258,7 +258,7 @@ router.put('/tasks/:id', (req: AuthRequest, res: Response) => {
     return res.status(403).json({ error: 'Admin only' });
   }
 
-  const { name, notes, frequencyDays, effort, isSeasonal, health, iconKey, assignedToChildren, assignedUserIds, assignmentMode, assignedUserPercentages } = req.body;
+  const { name, notes, frequencyDays, effort, isSeasonal, health, iconKey, assignedToChildren, assignedUserIds, assignmentMode, assignedUserPercentages, onDemand, showInDashboard } = req.body;
   const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id) as any;
   if (!task) return res.status(404).json({ error: 'Task not found' });
 
@@ -296,6 +296,8 @@ router.put('/tasks/:id', (req: AuthRequest, res: Response) => {
   if (resolvedAssignedToChildren !== undefined) { setClauses.push('assignedToChildren = ?'); params.push(resolvedAssignedToChildren); }
   const resolvedMode = assignmentMode !== undefined ? (['shared', 'custom'].includes(assignmentMode) ? assignmentMode : 'first') : undefined;
   if (resolvedMode !== undefined) { setClauses.push('assignmentMode = ?'); params.push(resolvedMode); }
+  if (onDemand !== undefined) { setClauses.push('onDemand = ?'); params.push(onDemand ? 1 : 0); }
+  if (showInDashboard !== undefined) { setClauses.push('showInDashboard = ?'); params.push(showInDashboard ? 1 : 0); }
 
   // Validate custom mode percentages sum to 100
   if (resolvedMode === 'custom' && Array.isArray(assignedUserIds) && assignedUserIds.length > 0) {
@@ -378,34 +380,36 @@ router.post('/tasks/:id/complete', (req: AuthRequest, res: Response) => {
   // Always use server timestamp — never trust client-supplied completedAt
   const now = new Date().toISOString();
 
-  // Block if effective user already completed this task today
-  const alreadyDoneBySelf = db.prepare(
-    "SELECT id FROM task_completions WHERE taskId = ? AND userId = ? AND status IN ('approved', 'pending') AND date(completedAt, 'localtime') = date(?, 'localtime')"
-  ).get(task.id, effectiveUserId, now);
-  if (alreadyDoneBySelf) {
-    return res.status(409).json({ error: 'already_done_today' });
-  }
-
-  if (task.assignmentMode !== 'shared' && task.assignmentMode !== 'custom') {
-    // In 'first' mode: block if someone else already completed today
-    const alreadyDoneByOther = db.prepare(
-      "SELECT id FROM task_completions WHERE taskId = ? AND userId != ? AND status IN ('approved', 'pending') AND date(completedAt, 'localtime') = date(?, 'localtime')"
+  if (!task.onDemand) {
+    // Block if effective user already completed this task today
+    const alreadyDoneBySelf = db.prepare(
+      "SELECT id FROM task_completions WHERE taskId = ? AND userId = ? AND status IN ('approved', 'pending') AND date(completedAt, 'localtime') = date(?, 'localtime')"
     ).get(task.id, effectiveUserId, now);
-    if (alreadyDoneByOther) {
-      return res.status(409).json({ error: 'already_done_by_other' });
+    if (alreadyDoneBySelf) {
+      return res.status(409).json({ error: 'already_done_today' });
     }
-  }
 
-  // Block if frequency cooldown hasn't elapsed (task not yet due)
-  if (task.lastCompletedAt) {
-    const globalVac = getGlobalVacation();
-    const taskAssigneesForVac = db.prepare('SELECT userId FROM task_assignees WHERE taskId = ?').all(task.id) as { userId: number }[];
-    const taskVac = taskAssigneesForVac.length === 1
-      ? resolveVacation(globalVac, getUserVacation(taskAssigneesForVac[0].userId))
-      : globalVac;
-    const currentHealth = calculateHealth(task.lastCompletedAt, task.frequencyDays, taskVac.isVacation, taskVac.startDate);
-    if (currentHealth > 0) {
-      return res.status(409).json({ error: 'not_yet_due', health: currentHealth });
+    if (task.assignmentMode !== 'shared' && task.assignmentMode !== 'custom') {
+      // In 'first' mode: block if someone else already completed today
+      const alreadyDoneByOther = db.prepare(
+        "SELECT id FROM task_completions WHERE taskId = ? AND userId != ? AND status IN ('approved', 'pending') AND date(completedAt, 'localtime') = date(?, 'localtime')"
+      ).get(task.id, effectiveUserId, now);
+      if (alreadyDoneByOther) {
+        return res.status(409).json({ error: 'already_done_by_other' });
+      }
+    }
+
+    // Block if frequency cooldown hasn't elapsed (task not yet due)
+    if (task.lastCompletedAt) {
+      const globalVac = getGlobalVacation();
+      const taskAssigneesForVac = db.prepare('SELECT userId FROM task_assignees WHERE taskId = ?').all(task.id) as { userId: number }[];
+      const taskVac = taskAssigneesForVac.length === 1
+        ? resolveVacation(globalVac, getUserVacation(taskAssigneesForVac[0].userId))
+        : globalVac;
+      const currentHealth = calculateHealth(task.lastCompletedAt, task.frequencyDays, taskVac.isVacation, taskVac.startDate);
+      if (currentHealth > 0) {
+        return res.status(409).json({ error: 'not_yet_due', health: currentHealth });
+      }
     }
   }
 


### PR DESCRIPTION
  Title: feat: On Demand tasks, dashboard restructure & card customisation

  Summary:
  - On Demand tasks (closes #17): tasks with no fixed schedule, completeable multiple times per day, with opt-in Show in Dashboard toggle
  - Dashboard restructure: Today's Quests → Ready to Complete + On Demand sections; new Scheduled card (upcoming, no Done button); new Completed Today card; old Next Tasks card removed
  - Dashboard card customisation: ⚙ Customise button to show/hide any of 11 cards, persisted to localStorage
  - Bug fix (#58): Math.ceil → Math.floor in Calendar.tsx for correct due-in-days display

  Test plan:
  - Create On Demand task — Done always enabled, completeable multiple times/day
  - Enable Show in Dashboard — task appears in On Demand section
  - Tasks past due → Ready to Complete with Done button; no false not_yet_due errors
  - Tasks not yet due → Scheduled card with due-in-days badge, no Done button
  - Complete a task → appears in Completed Today card
  - ⚙ Customise → toggle cards, refresh — preferences persist
  - All 5 languages (en, de, fr, es, it) display new strings correctly
  - Calendar shows 0d (not 1d) for tasks due today
