### PR TITLE
fix: resolve 4 CSS/UI bugs (#67, #70, #71, #78)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -311,6 +311,7 @@ function AppContent() {
           justifyContent: 'center',
           cursor: 'pointer',
           boxShadow: '0 2px 8px var(--warm-shadow)',
+          color: 'var(--warm-text)',
         }}
         aria-label="Open menu"
       >

--- a/client/src/components/pages/Dashboard.tsx
+++ b/client/src/components/pages/Dashboard.tsx
@@ -230,7 +230,12 @@ const Dashboard: React.FC<DashboardProps> = ({
       <div style={{ position: 'fixed', inset: 0, zIndex: 1000, display: 'flex', alignItems: 'flex-end', justifyContent: 'flex-end' }}
         onClick={(e) => { if (e.target === e.currentTarget) setShowCustomize(false); }}>
         <div style={{ background: 'var(--warm-card)', border: '1.5px solid var(--warm-border)', borderRadius: 20, padding: 24, margin: 20, minWidth: 260, boxShadow: '0 8px 32px rgba(0,0,0,0.18)' }}>
-          <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)', marginBottom: 16 }}>{t('dashboard.customise')}</div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+            <div style={{ fontSize: 14, fontWeight: 800, color: 'var(--warm-text)' }}>{t('dashboard.customise')}</div>
+            <button onClick={() => setShowCustomize(false)}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--warm-text-muted)', fontSize: 18, lineHeight: 1, padding: '0 2px' }}
+              aria-label="Close">✕</button>
+          </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {ALL_CARDS.map(card => (
               <label key={card.id} style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer' }}>
@@ -240,8 +245,6 @@ const Dashboard: React.FC<DashboardProps> = ({
               </label>
             ))}
           </div>
-          <button className="tq-btn tq-btn-secondary" onClick={() => setShowCustomize(false)}
-            style={{ marginTop: 16, width: '100%', fontSize: 12 }}>{t('common.cancel')}</button>
         </div>
       </div>
     )}

--- a/client/src/components/pages/RoomDetail.tsx
+++ b/client/src/components/pages/RoomDetail.tsx
@@ -59,7 +59,7 @@ function formatNextDue(lastCompletedAt: string | null, frequencyDays: number, t:
 
   const diffMinutes = Math.ceil(diffMs / (60 * 1000));
   const diffHours = Math.floor(diffMs / (60 * 60 * 1000));
-  const remainingMinutes = Math.ceil((diffMs % (60 * 60 * 1000)) / (60 * 1000));
+  const remainingMinutes = Math.floor((diffMs % (60 * 60 * 1000)) / (60 * 1000));
 
   if (diffMinutes < 60) {
     return { text: t('roomDetail.inMinutes').replace('{m}', `${Math.max(1, diffMinutes)}`), color: 'var(--health-yellow)' };
@@ -790,7 +790,7 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
                   className="tq-input"
                   style={{ flex: 1, resize: 'vertical' }} />
               </div>
-              <div className="task-add-form" style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+              <div className="task-add-form" style={{ display: 'flex', alignItems: 'center', gap: 20, minHeight: 30 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                   <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--warm-text-light)' }}>{t('roomDetail.onDemand')}</label>
                   <input type="checkbox" checked={newTaskOnDemand}


### PR DESCRIPTION
- #67: Use Math.floor for remainingMinutes in countdown to prevent _h 60m display
- #70: Replace cancel button on customise modal with X close button in header
- #71: Add minHeight to task-add-form row to prevent layout shift when toggling on-demand
- #78: Add color: var(--warm-text) to hamburger button so SVG icon respects night theme

