### PR TITLE
Sort task icon options alphabetically in dropdown

### DIFF
--- a/client/src/components/pages/RoomDetail.tsx
+++ b/client/src/components/pages/RoomDetail.tsx
@@ -500,9 +500,12 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
                       onChange={(e) => setEditForm((f) => ({ ...f, iconKey: e.target.value }))}
                       className="tq-input-compact"
                     >
-                      {TASK_ICON_OPTIONS.map((opt) => (
-                        <option key={opt.key} value={opt.key}>{t(`taskIcons.${opt.key}`)}</option>
-                      ))}
+                      {TASK_ICON_OPTIONS
+                        .slice()
+                        .sort((a, b) => a.label.localeCompare(b.label))
+                        .map((opt) => (
+                          <option key={opt.key} value={opt.key}>{t(`taskIcons.${opt.key}`)}</option>
+                        ))}
                     </select>
                   </div>
                   {/* Task assignment — only show if room has no room-level assignment */}


### PR DESCRIPTION
## Description

Sorts the task icon dropdown alphabetically (A-Z) when editing a chore in the room detail page, making it easier to find the desired icon.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Changes Made

- Sort `TASK_ICON_OPTIONS` array by label when rendering in the chore edit dropdown
- Uses `.slice()` to copy the array (avoid mutating original) before `.sort()`

## Testing

- [x] Tested locally with Docker (built via podman)
- [x] Tested on production-like environment (test container on port 3070)
- [ ] Added/updated tests
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary (per project conventions, no comments added)
- [x] My changes generate no new warnings or errors
- [x] I have checked for security vulnerabilities
- [x] I have not committed any secrets (.env, API keys, passwords)

## Screenshots

<img width="581" height="861" alt="image" src="https://github.com/user-attachments/assets/a68c58d8-fba0-4c9d-bc8a-db27635c4824" />


## Additional Notes

- No server, database, or API changes needed
- No new translations required
- Very minimal change with clear benefit