### PR TITLE
[Bug]: Editing task title shows untranslated value in non-English locales

### DIFF
--- a/client/src/components/pages/RoomDetail.tsx
+++ b/client/src/components/pages/RoomDetail.tsx
@@ -176,7 +176,7 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
   const { taskName: translateTask, roomDisplayName, timeAgo, t } = useTranslation(language);
   const [animatedTask, setAnimatedTask] = useState<number | null>(null);
   const [editingTask, setEditingTask] = useState<number | null>(null);
-  const [editForm, setEditForm] = useState({ name: '', notes: '', freqValue: 7, freqUnit: 'days', effort: 1, health: 100, healthChanged: false, iconKey: 'sparkle', onDemand: false, showInDashboard: false, assignmentType: 'none' as 'none' | 'users', assignmentUserIds: [] as number[], assignmentMode: 'first' as 'first' | 'shared' | 'custom' | 'rotating', assignmentPercentages: {} as Record<number, number>, customCoins: '' as string | number, allowEarlyCompletion: false });
+  const [editForm, setEditForm] = useState({ name: '', originalName: '', notes: '', freqValue: 7, freqUnit: 'days', effort: 1, health: 100, healthChanged: false, iconKey: 'sparkle', onDemand: false, showInDashboard: false, assignmentType: 'none' as 'none' | 'users', assignmentUserIds: [] as number[], assignmentMode: 'first' as 'first' | 'shared' | 'custom' | 'rotating', assignmentPercentages: {} as Record<number, number>, customCoins: '' as string | number, allowEarlyCompletion: false });
   const [taskMenuOpen, setTaskMenuOpen] = useState<number | null>(null);
   const [moveMenuTaskId, setMoveMenuTaskId] = useState<number | null>(null);
   const [allRooms, setAllRooms] = useState<Array<{ id: number; name: string; roomType: string }>>([]);
@@ -280,8 +280,9 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
     for (const u of task.assignedUsers || []) {
       assignmentPercentages[u.id] = u.coinPercentage ?? 0;
     }
+    const displayedName = translateTask(task.name, task.translationKey);
     setEditingTask(task.id);
-    setEditForm({ name: task.name, notes: task.notes || '', freqValue: value, freqUnit: unit, effort: task.effort, health: task.health, healthChanged: false, iconKey: task.iconKey || 'sparkle', onDemand: !!task.onDemand, showInDashboard: !!task.showInDashboard, assignmentType, assignmentUserIds, assignmentMode: (task.assignmentMode || 'first') as 'first' | 'shared' | 'custom' | 'rotating', assignmentPercentages, customCoins: task.customCoins ?? '', allowEarlyCompletion: !!task.allowEarlyCompletion });
+    setEditForm({ name: displayedName, originalName: displayedName, notes: task.notes || '', freqValue: value, freqUnit: unit, effort: task.effort, health: task.health, healthChanged: false, iconKey: task.iconKey || 'sparkle', onDemand: !!task.onDemand, showInDashboard: !!task.showInDashboard, assignmentType, assignmentUserIds, assignmentMode: (task.assignmentMode || 'first') as 'first' | 'shared' | 'custom' | 'rotating', assignmentPercentages, customCoins: task.customCoins ?? '', allowEarlyCompletion: !!task.allowEarlyCompletion });
   };
 
   const saveEdit = async () => {
@@ -291,7 +292,8 @@ export function RoomDetail({ room, language, isAdmin, currentUserId, currentUser
       editForm.assignmentType === 'users' ? { assignedToChildren: false, assignedUserIds: editForm.assignmentUserIds } :
       { assignedToChildren: false, assignedUserIds: [] };
     const assignedUserPercentages = editForm.assignmentMode === 'custom' ? editForm.assignmentPercentages : undefined;
-    await api.updateTask(editingTask, { name: editForm.name, notes: editForm.notes, frequencyDays, effort: editForm.effort, ...(editForm.healthChanged ? { health: editForm.health } : {}), iconKey: editForm.iconKey, onDemand: editForm.onDemand, showInDashboard: editForm.showInDashboard, assignmentMode: editForm.assignmentMode, assignedUserPercentages, customCoins: editForm.customCoins !== '' ? Number(editForm.customCoins) : null, allowEarlyCompletion: editForm.allowEarlyCompletion, ...assignmentPayload });
+    const nameChanged = editForm.name.trim() !== editForm.originalName.trim();
+    await api.updateTask(editingTask, { ...(nameChanged ? { name: editForm.name } : {}), notes: editForm.notes, frequencyDays, effort: editForm.effort, ...(editForm.healthChanged ? { health: editForm.health } : {}), iconKey: editForm.iconKey, onDemand: editForm.onDemand, showInDashboard: editForm.showInDashboard, assignmentMode: editForm.assignmentMode, assignedUserPercentages, customCoins: editForm.customCoins !== '' ? Number(editForm.customCoins) : null, allowEarlyCompletion: editForm.allowEarlyCompletion, ...assignmentPayload });
     setEditingTask(null);
     onRefresh?.();
   };


### PR DESCRIPTION
Fixes #111

## Description

The edit input is now pre-populated with the translated label, and saving without changing the title leaves the task as a template (translationKey preserved) so locale switches keep working until a modified task-title is provided.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Security fix

## Related Issue

<!-- Link to the issue this PR addresses, e.g., "Fixes #123" -->

Fixes #111

## Changes Made

When a user in a non-English locale (e.g. German) clicks "edit" on a template task title, the input pre-populates with the raw English task.name (e.g. "Wash Dishes") instead of the translated value they currently see on screen (e.g. "Geschirr spülen").

A second, hidden problem was identified: the backend always clears translationKey whenever name is provided in the update payload (server/src/routes/tasks.ts:302). The current frontend always sends name on save, so even opening + saving a template task with no changes silently converts it to a custom task. 

This fix provides: the edit input is pre-populated with the translated label, and saving without changing the title leaves the task as a template (translationKey preserved) so locale switches keep working until a modified task-title is provided.

All changes were done in client/src/components/pages/RoomDetail.tsx.

## Testing & Verification

<!-- Describe how you tested your changes -->
1. Run the client (cd client && npm run dev) and the server.
2. Log in, switch language to German in Settings.
3. Navigate to a room with default tasks. Confirm a task displays its German title (e.g. "Geschirr spülen").
4. Click edit on that task. Expected: input shows "Geschirr spülen", not "Wash Dishes".
5. Save without changing anything. Reload. Expected: task still displays "Geschirr spülen". Switch language to French. Expected: task now displays the French translation (proves translationKey was preserved).
6. Edit the task again, change the title to "Mein eigener Titel", save. Reload, switch language to English. Expected: task displays "Mein eigener Titel" (custom title, translationKey cleared — expected behavior).
7. Repeat step 4 with a task that was never a template (no translationKey) — input should show the literal name as before. Verify no regression for custom tasks.
8. Run the existing test suite (npm test in client/ and server/) and make sure nothing breaks.

- [x] Tested locally with Docker
- [ ] Tested on production-like environment
- [ ] Added/updated tests
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation (README, API.md, etc.)
- [x] My changes generate no new warnings or errors
- [x] I have checked for security vulnerabilities
- [x] I have not committed any secrets (.env, API keys, passwords)


